### PR TITLE
any 2xx status code should be treated as success.

### DIFF
--- a/oauth.go
+++ b/oauth.go
@@ -558,7 +558,8 @@ func (c *Consumer) httpExecute(
 		}
 	}
 
-	if resp.StatusCode != http.StatusOK {
+	// StatusMultipleChoices is 300, any 2xx response should be treated as success
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 		bytes, _ := ioutil.ReadAll(resp.Body)
 		resp.Body.Close()
 


### PR DESCRIPTION
some APIs return 2xx status codes that aren't 200, e.g. 201 is popular, this treats any 2xx response status code as success.
