### PR TITLE
Return HTTP response even on non-2XX responses. Clients might want it.

### DIFF
--- a/oauth.go
+++ b/oauth.go
@@ -561,9 +561,8 @@ func (c *Consumer) httpExecute(
 	// StatusMultipleChoices is 300, any 2xx response should be treated as success
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 		bytes, _ := ioutil.ReadAll(resp.Body)
-		resp.Body.Close()
 
-		return nil, errors.New("HTTP response is not 200/OK as expected. Actual response: \n" +
+		return resp, errors.New("HTTP response is not 200/OK as expected. Actual response: \n" +
 			"\tResponse Status: '" + resp.Status + "'\n" +
 			"\tResponse Code: " + strconv.Itoa(resp.StatusCode) + "\n" +
 			"\tResponse Body: " + string(bytes) + "\n" +

--- a/oauth_test.go
+++ b/oauth_test.go
@@ -243,10 +243,13 @@ func Test404OnGet(t *testing.T) {
 	m.httpClient.ReturnStatusCode(404, "Not Found")
 
 	atoken := &AccessToken{Token: "ATOKEN", Secret: "ASECRET"}
-	_, err := c.Get("URL", map[string]string{}, atoken)
+	resp, err := c.Get("URL", map[string]string{}, atoken)
 	if err == nil {
 		t.Fatal("Should have raised an error")
 	}
+
+	assertEqM(t, 404, resp.StatusCode, "Response status code should equal the status code from HTTP response")
+
 }
 
 func TestMissingRequestTokenSecret(t *testing.T) {


### PR DESCRIPTION
For https://github.com/mrjones/oauth/issues/8
