### PR TITLE
Adds support for two-legged OAuth calls

### DIFF
--- a/oauth.go
+++ b/oauth.go
@@ -461,14 +461,17 @@ func (s *SHA1Signer) Debug(enabled bool) {
 
 func (s *SHA1Signer) Sign(message string, key string) string {
 	if s.debug {
-		fmt.Println("Signing:" + message)
-		fmt.Println("Key:" + key)
+		fmt.Println("Signing:", message)
+		fmt.Println("Key:", key)
 	}
 	hashfun := hmac.New(sha1.New, []byte(key))
 	hashfun.Write([]byte(message))
 	rawsignature := hashfun.Sum(nil)
 	base64signature := make([]byte, base64.StdEncoding.EncodedLen(len(rawsignature)))
 	base64.StdEncoding.Encode(base64signature, rawsignature)
+	if s.debug {
+		fmt.Println("Base64 signature:", string(base64signature))
+	}
 	return string(base64signature)
 }
 


### PR DESCRIPTION
I am trying to write a client for http://context.io, however they use two-legged OAuth 1.0, which means actively _not_ sending the `oauth_token` parameter in the request.

The tests pass, and all of that good stuff.
