### PR TITLE
Updates twitter example to use Twitter API 1.1

### DIFF
--- a/examples/twitter/twitter.go
+++ b/examples/twitter/twitter.go
@@ -75,7 +75,7 @@ func main() {
 	}
 
 	response, err := c.Get(
-		"http://api.twitter.com/1/statuses/home_timeline.json",
+		"http://api.twitter.com/1.1/statuses/home_timeline.json",
 		map[string]string{"count": "1"},
 		accessToken)
 	if err != nil {
@@ -90,7 +90,7 @@ func main() {
 		status := fmt.Sprintf("Test post via the API using Go (http://golang.org/) at %s", time.Now().String())
 
 		response, err = c.Post(
-			"http://api.twitter.com/1/statuses/update.json",
+			"http://api.twitter.com/1.1/statuses/update.json",
 			map[string]string{
 				"status": status,
 			},


### PR DESCRIPTION
Twitter API 1 has been deprecated. See https://dev.twitter.com/docs/faq#17750

This small fix changes the example to use version 1.1
