### PR TITLE
enable passing custom httpClient to consumer

### DIFF
--- a/oauth.go
+++ b/oauth.go
@@ -196,6 +196,30 @@ func newConsumer(consumerKey string, serviceProvider ServiceProvider, httpClient
 //        see the documentation for ServiceProvider for how to create this.
 //
 func NewConsumer(consumerKey string, consumerSecret string,
+	serviceProvider ServiceProvider) *Consumer {
+	consumer := newConsumer(consumerKey, serviceProvider, nil)
+
+	consumer.signer = &SHA1Signer{
+		consumerSecret: consumerSecret,
+	}
+
+	return consumer
+}
+
+// Creates a new Consumer instance, with a HMAC-SHA1 signer
+//      - consumerKey and consumerSecret:
+//        values you should obtain from the ServiceProvider when you register your
+//        application.
+//
+//      - serviceProvider:
+//        see the documentation for ServiceProvider for how to create this.
+//
+//		- httpClient:
+//		  Provides a custom implementation of the httpClient used under the hood
+//		  to make the request.  This is especially useful if you want to use
+//		  Google App Engine.
+//
+func NewCustomHttpClientConsumer(consumerKey string, consumerSecret string,
 	serviceProvider ServiceProvider, httpClient *http.Client) *Consumer {
 	consumer := newConsumer(consumerKey, serviceProvider, httpClient)
 
@@ -204,7 +228,6 @@ func NewConsumer(consumerKey string, consumerSecret string,
 	}
 
 	return consumer
-
 }
 
 // Creates a new Consumer instance, with a RSA-SHA1 signer

--- a/oauth.go
+++ b/oauth.go
@@ -170,14 +170,16 @@ type Consumer struct {
 	signer         signer
 }
 
-func newConsumer(consumerKey string,
-	serviceProvider ServiceProvider) *Consumer {
+func newConsumer(consumerKey string, serviceProvider ServiceProvider, httpClient *http.Client) *Consumer {
 	clock := &defaultClock{}
+	if httpClient == nil {
+		httpClient = &http.Client{}
+	}
 	return &Consumer{
 		consumerKey:     consumerKey,
 		serviceProvider: serviceProvider,
 		clock:           clock,
-		HttpClient:      &http.Client{},
+		HttpClient:      httpClient,
 		nonceGenerator:  rand.New(rand.NewSource(clock.Nanos())),
 
 		AdditionalParams:                 make(map[string]string),
@@ -194,8 +196,8 @@ func newConsumer(consumerKey string,
 //        see the documentation for ServiceProvider for how to create this.
 //
 func NewConsumer(consumerKey string, consumerSecret string,
-	serviceProvider ServiceProvider) *Consumer {
-	consumer := newConsumer(consumerKey, serviceProvider)
+	serviceProvider ServiceProvider, httpClient *http.Client) *Consumer {
+	consumer := newConsumer(consumerKey, serviceProvider, httpClient)
 
 	consumer.signer = &SHA1Signer{
 		consumerSecret: consumerSecret,
@@ -218,7 +220,7 @@ func NewConsumer(consumerKey string, consumerSecret string,
 //
 func NewRSAConsumer(consumerKey string, privateKey *rsa.PrivateKey,
 	serviceProvider ServiceProvider) *Consumer {
-	consumer := newConsumer(consumerKey, serviceProvider)
+	consumer := newConsumer(consumerKey, serviceProvider, nil)
 
 	consumer.signer = &RSASigner{
 		privateKey: privateKey,

--- a/oauth_test.go
+++ b/oauth_test.go
@@ -485,7 +485,8 @@ func basicConsumer() *Consumer {
 			RequestTokenUrl:   "http://www.mrjon.es/requesttoken",
 			AuthorizeTokenUrl: "http://www.mrjon.es/authorizetoken",
 			AccessTokenUrl:    "http://www.mrjon.es/accesstoken",
-		})
+		},
+		nil)
 }
 
 func assertEq(t *testing.T, expected interface{}, actual interface{}) {

--- a/oauth_test.go
+++ b/oauth_test.go
@@ -485,8 +485,7 @@ func basicConsumer() *Consumer {
 			RequestTokenUrl:   "http://www.mrjon.es/requesttoken",
 			AuthorizeTokenUrl: "http://www.mrjon.es/authorizetoken",
 			AccessTokenUrl:    "http://www.mrjon.es/accesstoken",
-		},
-		nil)
+		})
 }
 
 func assertEq(t *testing.T, expected interface{}, actual interface{}) {


### PR DESCRIPTION
I am trying to use this package with google app engine.  That seems to require using their implementation of http.Client, instead of the default client.  

https://cloud.google.com/appengine/docs/go/urlfetch/

