### PR TITLE
Fixed oauth for Trello

### DIFF
--- a/examples/trello/trello.go
+++ b/examples/trello/trello.go
@@ -63,7 +63,7 @@ func main() {
 
 	c.Debug(true)
 
-	requestToken, u, err := c.GetRequestTokenAndUrl("oob")
+	requestToken, u, err := c.GetRequestTokenAndUrl("")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/oauth.go
+++ b/oauth.go
@@ -287,7 +287,9 @@ func NewRSAConsumer(consumerKey string, privateKey *rsa.PrivateKey,
 //        Set only if there was an error, nil otherwise.
 func (c *Consumer) GetRequestTokenAndUrl(callbackUrl string) (rtoken *RequestToken, loginUrl string, err error) {
 	params := c.baseParams(c.consumerKey, c.AdditionalParams)
-	params.Add(CALLBACK_PARAM, callbackUrl)
+	if callbackUrl != "" {
+		params.Add(CALLBACK_PARAM, callbackUrl)
+	}
 
 	req := &request{
 		method:      c.serviceProvider.httpMethod(),


### PR DESCRIPTION
Fixed oauth for Trello. Trello no longer supports "oob" and hangs
on to the callbackUrl when supplied. This results in 404 error
upon verification. Fix is to not pass the callbackUrl which results
in Trello servers performing the expected out-of-band verification
and presents a web page with the verification code.