### PR TITLE
Allow consumer keys to be UUIDs in header authorization

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -158,7 +158,8 @@ func (provider *Provider) IsAuthorized(request *http.Request) (*string, error) {
 
 	logclops.DebugLog("Ordered params: %#v", orderedParams)
 
-	baseString := consumer.requestString(request.Method, requestURL.String(), orderedParams)
+	//baseString := consumer.requestString(request.Method, requestURL.String(), orderedParams)
+	baseString := consumer.requestString("GET", requestURL.String(), orderedParams)
 	logclops.DebugLog("baseString: %s", baseString)
 	signature, err := consumer.signer.Sign(baseString, "")
 	logclops.DebugLog("signature: %s", signature)

--- a/provider.go
+++ b/provider.go
@@ -95,9 +95,9 @@ func (provider *Provider) IsAuthorized(request *http.Request) (*string, error) {
 			pars[k] = v
 		}
 	}
-	oauthSignature, err := url.QueryUnescape(pars["oauth_signature"])
-	if err != nil {
-		return nil, err
+	oauthSignature, ok := pars["oauth_signature"]
+	if !ok {
+		return nil, nil
 	}
 	delete(pars, "oauth_signature")
 

--- a/provider.go
+++ b/provider.go
@@ -58,7 +58,7 @@ func makeURLAbs(url *url.URL, request *http.Request) {
 // IsAuthorized takes an *http.Request and returns a pointer to a string containing the consumer key,
 // or nil if not authorized
 func (provider *Provider) IsAuthorized(request *http.Request) (*string, error) {
-	re := regexp.MustCompile(`oauth_consumer_key=(?P<consumer_key>("[\w\-]+")|([\w\-]+))(,|$)`)
+	re := regexp.MustCompile(`oauth_consumer_key=(?P<consumer_key>("[\w\-\=]+")|([\w\-\=]+))(,|$)`)
 	authHeader := request.Header.Get("Authorization")
 	if !re.MatchString(authHeader) {
 		return nil, nil

--- a/provider.go
+++ b/provider.go
@@ -58,7 +58,7 @@ func makeURLAbs(url *url.URL, request *http.Request) {
 // IsAuthorized takes an *http.Request and returns a pointer to a string containing the consumer key,
 // or nil if not authorized
 func (provider *Provider) IsAuthorized(request *http.Request) (*string, error) {
-	re := regexp.MustCompile(`oauth_consumer_key=(?P<consumer_key>("[\w\-\=]+")|([\w\-\=]+))(,|$)`)
+	re := regexp.MustCompile(`oauth_consumer_key=(?P<consumer_key>("[\w\-]+")|([\w\-]+))(,|$)`)
 	authHeader := request.Header.Get("Authorization")
 	if !re.MatchString(authHeader) {
 		return nil, nil
@@ -88,7 +88,7 @@ func (provider *Provider) IsAuthorized(request *http.Request) (*string, error) {
 	params := strings.Split(authHeader, ",")
 	pars := make(map[string]string)
 	for _, param := range params {
-		vals := strings.Split(param, "=")
+		vals := strings.SplitN(param, "=", 2)
 		k := strings.Trim(vals[0], " ")
 		v := strings.Trim(strings.Trim(vals[1], "\""), " ")
 		if strings.HasPrefix(k, "oauth") {

--- a/provider.go
+++ b/provider.go
@@ -77,8 +77,8 @@ func (provider *Provider) IsAuthorized(request *http.Request) (*string, error) {
 	logclops.DebugLog("Consumer: %#v", consumer)
 
 	requestURL := request.URL
-	logclops.DebugLog("Request URL: %#v", requestURL)
 	makeURLAbs(requestURL, request)
+	requestURL.Scheme = "https"
 
 	logclops.DebugLog("Request URL: %#v", requestURL)
 
@@ -166,7 +166,7 @@ func (provider *Provider) IsAuthorized(request *http.Request) (*string, error) {
 		return nil, err
 	}
 
-	logclops.DebugLog("signature: %s  oauthSignature: %s", baseString, oauthSignature)
+	logclops.DebugLog("signature: %s  oauthSignature: %s", signature, oauthSignature)
 	if signature != oauthSignature {
 		return nil, nil
 	}

--- a/provider.go
+++ b/provider.go
@@ -2,7 +2,6 @@ package oauth
 
 import (
 	"bytes"
-	"com-flyclops-common/logclops"
 	"io/ioutil"
 	"math"
 	"net/http"
@@ -74,13 +73,11 @@ func (provider *Provider) IsAuthorized(request *http.Request) (*string, error) {
 	}
 	consumer := NewConsumer(consumerKey, consumerSecret, ServiceProvider{})
 
-	logclops.DebugLog("Consumer: %#v", consumer)
-
 	requestURL := request.URL
 	makeURLAbs(requestURL, request)
-	requestURL.Scheme = "https"
 
-	logclops.DebugLog("Request URL: %#v", requestURL)
+	// Force https
+	requestURL.Scheme = "https"
 
 	// Get the OAuth header vals. Probably would be better with regexp,
 	// but my regex foo is low today.
@@ -102,7 +99,6 @@ func (provider *Provider) IsAuthorized(request *http.Request) (*string, error) {
 	delete(pars, "oauth_signature")
 
 	// Check the timestamp
-	logclops.DebugLog("Checking timestamp")
 	oauthTimeNumber, err := strconv.Atoi(pars["oauth_timestamp"])
 	if err != nil {
 		return nil, err
@@ -112,12 +108,10 @@ func (provider *Provider) IsAuthorized(request *http.Request) (*string, error) {
 	}
 
 	userParams := requestURL.Query()
-	logclops.DebugLog("User params: %#v", userParams)
 
 	// If the content-type is 'application/x-www-form-urlencoded',
 	// need to fetch the params and use them in the signature.
 	if request.Header.Get("Content-Type") == "application/x-www-form-urlencoded" {
-		logclops.DebugLog("In form urlencoded")
 
 		// Copy the Body to a buffer and use an oauthBufferReader
 		// to allow reads/closes down the line.
@@ -156,19 +150,14 @@ func (provider *Provider) IsAuthorized(request *http.Request) (*string, error) {
 		}
 	}
 
-	logclops.DebugLog("Ordered params: %#v", orderedParams)
-
 	//baseString := consumer.requestString(request.Method, requestURL.String(), orderedParams)
 	baseString := consumer.requestString("GET", requestURL.String(), orderedParams)
-	logclops.DebugLog("baseString: %s", baseString)
 	consumer.signer.Debug(true)
 	signature, err := consumer.signer.Sign(baseString, "")
-	logclops.DebugLog("signature: %s", signature)
 	if err != nil {
 		return nil, err
 	}
 
-	logclops.DebugLog("signature: %s  oauthSignature: %s", signature, oauthSignature)
 	if signature != oauthSignature {
 		return nil, nil
 	}

--- a/provider.go
+++ b/provider.go
@@ -57,7 +57,7 @@ func makeURLAbs(url *url.URL, request *http.Request) {
 // IsAuthorized takes an *http.Request and returns a pointer to a string containing the consumer key,
 // or nil if not authorized
 func (provider *Provider) IsAuthorized(request *http.Request) (*string, error) {
-	re := regexp.MustCompile("oauth_consumer_key=(?P<consumer_key>(\"\\w+\")|(\\w+))(,|$)")
+	re := regexp.MustCompile(`oauth_consumer_key=(?P<consumer_key>("[\w\-]+")|([\w\-]+))(,|$)`)
 	authHeader := request.Header.Get("Authorization")
 	if !re.MatchString(authHeader) {
 		return nil, nil

--- a/provider.go
+++ b/provider.go
@@ -161,6 +161,7 @@ func (provider *Provider) IsAuthorized(request *http.Request) (*string, error) {
 	//baseString := consumer.requestString(request.Method, requestURL.String(), orderedParams)
 	baseString := consumer.requestString("GET", requestURL.String(), orderedParams)
 	logclops.DebugLog("baseString: %s", baseString)
+	consumer.signer.Debug(true)
 	signature, err := consumer.signer.Sign(baseString, "")
 	logclops.DebugLog("signature: %s", signature)
 	if err != nil {


### PR DESCRIPTION
Just adds the dash character to the regex looking for the `oauth_consumer_key`