### PR TITLE
Protect trailing = in signature

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -82,7 +82,7 @@ func (provider *Provider) IsAuthorized(request *http.Request) (*string, error) {
 	params := strings.Split(authHeader, ",")
 	pars := make(map[string]string)
 	for _, param := range params {
-		vals := strings.Split(param, "=")
+		vals := strings.SplitN(param, "=", 2)
 		k := strings.Trim(vals[0], " ")
 		v := strings.Trim(strings.Trim(vals[1], "\""), " ")
 		if strings.HasPrefix(k, "oauth") {

--- a/provider.go
+++ b/provider.go
@@ -57,7 +57,7 @@ func makeURLAbs(url *url.URL, request *http.Request) {
 // IsAuthorized takes an *http.Request and returns a pointer to a string containing the consumer key,
 // or nil if not authorized
 func (provider *Provider) IsAuthorized(request *http.Request) (*string, error) {
-	re := regexp.MustCompile("oauth_consumer_key=(?P<consumer_key>(\"\\w+\")|(\\w+))(,|$)")
+	re := regexp.MustCompile(`oauth_consumer_key=(?P<consumer_key>("[\w\-]+")|([\w\-]+))(,|$)`)
 	authHeader := request.Header.Get("Authorization")
 	if !re.MatchString(authHeader) {
 		return nil, nil


### PR DESCRIPTION
Some signatures can end in an equal sign (ex: `QE5GoUkrrI1SC/XmORhLGEeGe/c=` )

This fix stops the param splitter from over-splitting, instead splitting only on the first equal sign and leaving subsequent equal signs as part of the value in the KV pair.