### PR TITLE
Allow consumer keys to be UUIDs in header authorization

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -57,7 +57,7 @@ func makeURLAbs(url *url.URL, request *http.Request) {
 // IsAuthorized takes an *http.Request and returns a pointer to a string containing the consumer key,
 // or nil if not authorized
 func (provider *Provider) IsAuthorized(request *http.Request) (*string, error) {
-	re := regexp.MustCompile("oauth_consumer_key=(?P<consumer_key>(\"\\w+\")|(\\w+))(,|$)")
+	re := regexp.MustCompile(`oauth_consumer_key=(?P<consumer_key>("[\w\-]+")|([\w\-]+))(,|$)`)
 	authHeader := request.Header.Get("Authorization")
 	if !re.MatchString(authHeader) {
 		return nil, nil


### PR DESCRIPTION
This is the appropriate PR. Just allows UUIDs to be used as the `oauth_consumer_key`.

May not be general enough, or perhaps even more characters (underscore?) should be allowed as well.