### PR TITLE
Provider support for RSA signatures

### DIFF
--- a/oauth.go
+++ b/oauth.go
@@ -315,7 +315,7 @@ func (c *Consumer) GetRequestTokenAndUrl(callbackUrl string) (rtoken *RequestTok
 	for k, v := range c.AdditionalAuthorizationUrlParams {
 		loginParams.Set(k, v)
 	}
-	loginParams.Set("oauth_token", requestToken.Token)
+	loginParams.Set(TOKEN_PARAM, requestToken.Token)
 
 	loginUrl = c.serviceProvider.AuthorizeTokenUrl + "?" + loginParams.Encode()
 

--- a/oauth.go
+++ b/oauth.go
@@ -62,6 +62,7 @@ const (
 	SIGNATURE_METHOD_HMAC_SHA1 = "HMAC-SHA1"
 	SIGNATURE_METHOD_RSA_SHA1  = "RSA-SHA1"
 
+	OAUTH_HEADER           = "OAuth "
 	CALLBACK_PARAM         = "oauth_callback"
 	CONSUMER_KEY_PARAM     = "oauth_consumer_key"
 	NONCE_PARAM            = "oauth_nonce"
@@ -736,7 +737,7 @@ func (rt *RoundTripper) RoundTrip(userRequest *http.Request) (*http.Response, er
 	authParams.Add(SIGNATURE_PARAM, signature)
 
 	// Set auth header.
-	oauthHdr := "OAuth "
+	oauthHdr := OAUTH_HEADER
 	for pos, key := range authParams.Keys() {
 		for innerPos, value := range authParams.Get(key) {
 			if pos+innerPos > 0 {

--- a/oauth_test.go
+++ b/oauth_test.go
@@ -1,6 +1,7 @@
 package oauth
 
 import (
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -1161,6 +1162,13 @@ func (m *MockSigner) Sign(message string, tokenSecret string) (string, error) {
 	m.UsedKey = m.ConsumerSecret + "&" + tokenSecret
 	m.SignedString = message
 	return "MOCK_SIGNATURE", nil
+}
+
+func (m *MockSigner) Verify(message string, signature string) error {
+	if signature != "MOCK_SIGNATURE" {
+		return fmt.Errorf("bad mock signature")
+	}
+	return nil
 }
 
 func (m *MockSigner) Debug(enabled bool) {}

--- a/provider.go
+++ b/provider.go
@@ -79,14 +79,14 @@ func (provider *Provider) IsAuthorized(request *http.Request) (*string, error) {
 			pars[k] = v
 		}
 	}
-	oauthSignature, err := url.QueryUnescape(pars["oauth_signature"])
+	oauthSignature, err := url.QueryUnescape(pars[SIGNATURE_PARAM])
 	if err != nil {
 		return nil, err
 	}
-	delete(pars, "oauth_signature")
+	delete(pars, SIGNATURE_PARAM)
 
 	// Check the timestamp
-	oauthTimeNumber, err := strconv.Atoi(pars["oauth_timestamp"])
+	oauthTimeNumber, err := strconv.Atoi(pars[TIMESTAMP_PARAM])
 	if err != nil {
 		return nil, err
 	}

--- a/provider.go
+++ b/provider.go
@@ -148,13 +148,9 @@ func (provider *Provider) IsAuthorized(request *http.Request) (*string, error) {
 	}
 
 	baseString := consumer.requestString(request.Method, requestURL.String(), orderedParams)
-	signature, err := consumer.signer.Sign(baseString, "")
+	err = consumer.signer.Verify(baseString, oauthSignature)
 	if err != nil {
 		return nil, err
-	}
-
-	if signature != oauthSignature {
-		return nil, nil
 	}
 
 	return &consumerKey, nil

--- a/provider.go
+++ b/provider.go
@@ -47,10 +47,10 @@ func NewProvider(secretGetter ConsumerGetter) *Provider {
 func makeURLAbs(url *url.URL, request *http.Request) {
 	if !url.IsAbs() {
 		url.Host = request.Host
-		if strings.HasPrefix(request.Proto, "HTTP/") {
-			url.Scheme = "http"
-		} else {
+		if request.TLS != nil || request.Header.Get("X-Forwarded-Proto") == "https" {
 			url.Scheme = "https"
+		} else {
+			url.Scheme = "http"
 		}
 	}
 }

--- a/provider_test.go
+++ b/provider_test.go
@@ -6,7 +6,9 @@ import (
 )
 
 func TestProviderIsAuthorizedGood(t *testing.T) {
-	p := NewProvider(func(s string) (string, error) { return "consumersecret", nil })
+	p := NewProvider(func(s string, h map[string]string) (*Consumer, error) {
+		return NewConsumer(s, "consumersecret", ServiceProvider{}), nil
+	})
 	p.clock = &MockClock{Time: 1446226936}
 
 	fakeRequest, err := http.NewRequest("GET", "https://example.com/some/path?q=query&q=another_query", nil)


### PR DESCRIPTION
I've done a small refactor of the Provider library to support verifying RSA based signatures.

1. Turned the SecretGetter into a ConsumerGetter and plumbed in the full oauth header. This allows the getter to detect and return the correct consumer type. This should also resolve the issues in #44 and #45.
2. Added a verify function to the signer interface to allow signatures to be verified with only a public key.
3. Fixed a minor issue in detecting HTTPS requests.
4. Fixed some constants not using the _PARAM variables.

Thanks for providing this great OAuth library!