### PR TITLE
Add optional oauth features

### DIFF
--- a/oauth.go
+++ b/oauth.go
@@ -41,7 +41,6 @@ import (
 	"crypto/hmac"
 	cryptoRand "crypto/rand"
 	"crypto/rsa"
-	"crypto/sha1"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -909,9 +908,12 @@ func (s *SHA1Signer) Sign(message string, tokenSecret string) (string, error) {
 		fmt.Println("Signing:", message)
 		fmt.Println("Key:", key)
 	}
-	hashfun := hmac.New(sha1.New, []byte(key))
-	hashfun.Write([]byte(message))
-	rawSignature := hashfun.Sum(nil)
+
+	hashFunc := crypto.SHA1
+	h := hmac.New(hashFunc.New, []byte(key))
+	h.Write([]byte(message))
+	rawSignature := h.Sum(nil)
+
 	base64signature := base64.StdEncoding.EncodeToString(rawSignature)
 	if s.debug {
 		fmt.Println("Base64 signature:", base64signature)

--- a/oauth.go
+++ b/oauth.go
@@ -205,7 +205,7 @@ func NewConsumer(consumerKey string, consumerSecret string,
 	serviceProvider ServiceProvider) *Consumer {
 	consumer := newConsumer(consumerKey, serviceProvider, nil)
 
-	consumer.signer = &SHA1Signer{
+	consumer.signer = &HMACSigner{
 		consumerSecret: consumerSecret,
 	}
 
@@ -229,7 +229,7 @@ func NewCustomHttpClientConsumer(consumerKey string, consumerSecret string,
 	serviceProvider ServiceProvider, httpClient *http.Client) *Consumer {
 	consumer := newConsumer(consumerKey, serviceProvider, httpClient)
 
-	consumer.signer = &SHA1Signer{
+	consumer.signer = &HMACSigner{
 		consumerSecret: consumerSecret,
 	}
 
@@ -893,16 +893,16 @@ func parseAdditionalData(parts url.Values) map[string]string {
 	return params
 }
 
-type SHA1Signer struct {
+type HMACSigner struct {
 	consumerSecret string
 	debug          bool
 }
 
-func (s *SHA1Signer) Debug(enabled bool) {
+func (s *HMACSigner) Debug(enabled bool) {
 	s.debug = enabled
 }
 
-func (s *SHA1Signer) Sign(message string, tokenSecret string) (string, error) {
+func (s *HMACSigner) Sign(message string, tokenSecret string) (string, error) {
 	key := escape(s.consumerSecret) + "&" + escape(tokenSecret)
 	if s.debug {
 		fmt.Println("Signing:", message)
@@ -921,7 +921,7 @@ func (s *SHA1Signer) Sign(message string, tokenSecret string) (string, error) {
 	return base64signature, nil
 }
 
-func (s *SHA1Signer) Verify(message string, signature string) error {
+func (s *HMACSigner) Verify(message string, signature string) error {
 	if s.debug {
 		fmt.Println("Verifying Base64 signature:", signature)
 	}
@@ -937,7 +937,7 @@ func (s *SHA1Signer) Verify(message string, signature string) error {
 	return nil
 }
 
-func (s *SHA1Signer) SignatureMethod() string {
+func (s *HMACSigner) SignatureMethod() string {
 	return SIGNATURE_METHOD_HMAC_SHA1
 }
 

--- a/oauth.go
+++ b/oauth.go
@@ -62,6 +62,7 @@ const (
 	SIGNATURE_METHOD_HMAC = "HMAC-"
 	SIGNATURE_METHOD_RSA  = "RSA-"
 
+	HTTP_AUTH_HEADER       = "Authorization"
 	OAUTH_HEADER           = "OAuth "
 	CALLBACK_PARAM         = "oauth_callback"
 	CONSUMER_KEY_PARAM     = "oauth_consumer_key"
@@ -816,7 +817,7 @@ func (rt *RoundTripper) RoundTrip(userRequest *http.Request) (*http.Response, er
 			oauthHdr += key + "=\"" + value + "\""
 		}
 	}
-	serverRequest.Header.Add("Authorization", oauthHdr)
+	serverRequest.Header.Add(HTTP_AUTH_HEADER, oauthHdr)
 
 	if rt.consumer.debug {
 		fmt.Printf("Request: %v\n", serverRequest)

--- a/oauth_test.go
+++ b/oauth_test.go
@@ -1,6 +1,7 @@
 package oauth
 
 import (
+	"crypto"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -1174,5 +1175,9 @@ func (m *MockSigner) Verify(message string, signature string) error {
 func (m *MockSigner) Debug(enabled bool) {}
 
 func (m *MockSigner) SignatureMethod() string {
-	return SIGNATURE_METHOD_HMAC_SHA1
+	return SIGNATURE_METHOD_HMAC + HASH_METHOD_MAP[m.HashFunc()]
+}
+
+func (m *MockSigner) HashFunc() crypto.Hash {
+	return crypto.SHA1
 }

--- a/oauth_test.go
+++ b/oauth_test.go
@@ -1021,7 +1021,7 @@ func (mock *MockHttpClient) Do(req *http.Request) (*http.Response, error) {
 		if req.Header == nil {
 			mock.t.Fatal("Missing 'Authorization' header.")
 		}
-		mock.oAuthChecker.CheckHeader(req.Header.Get("Authorization"))
+		mock.oAuthChecker.CheckHeader(req.Header.Get(HTTP_AUTH_HEADER))
 	}
 
 	if len(mock.expectedHeaders) > 0 {

--- a/oauth_test.go
+++ b/oauth_test.go
@@ -956,6 +956,36 @@ func TestSemicolonInParameters_NewApi(t *testing.T) {
 	assertEq(t, "BODY:SUCCESS", string(body))
 }
 
+func TestBodyHashStandard(t *testing.T) {
+	m := newMocks(t)
+
+	req, err := http.NewRequest("POST", "http://www.mrjon.es/someurl", strings.NewReader(`foo=123`))
+	assertEq(t, nil, err)
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	hash, err := calculateBodyHash(req, m.signer)
+	assertEq(t, nil, err)
+	assertEq(t, "", hash)
+
+	req, err = http.NewRequest("GET", "http://www.mrjon.es/someurl?foo=123", nil)
+	assertEq(t, nil, err)
+	hash, err = calculateBodyHash(req, m.signer)
+	assertEq(t, nil, err)
+	assertEq(t, "2jmj7l5rSw0yVb/vlWAYkK/YBwk=", hash)
+
+	req, err = http.NewRequest("GET", "http://www.mrjon.es/someurl?foo=123", strings.NewReader(""))
+	assertEq(t, nil, err)
+	hash, err = calculateBodyHash(req, m.signer)
+	assertEq(t, nil, err)
+	assertEq(t, "2jmj7l5rSw0yVb/vlWAYkK/YBwk=", hash)
+
+	req, err = http.NewRequest("GET", "http://www.mrjon.es/someurl?foo=123", strings.NewReader("Hello World!"))
+	assertEq(t, nil, err)
+	hash, err = calculateBodyHash(req, m.signer)
+	assertEq(t, nil, err)
+	assertEq(t, "Lve95gjOVATpfV8EL5X4nxwjKHE=", hash)
+
+}
+
 func basicConsumer() *Consumer {
 	return NewConsumer(
 		"consumerkey",

--- a/provider.go
+++ b/provider.go
@@ -63,7 +63,7 @@ func (provider *Provider) IsAuthorized(request *http.Request) (*string, error) {
 
 	// Get the OAuth header vals. Probably would be better with regexp,
 	// but my regex foo is low today.
-	authHeader := request.Header.Get("Authorization")
+	authHeader := request.Header.Get(HTTP_AUTH_HEADER)
 	if strings.EqualFold(OAUTH_HEADER, authHeader[0:5]) {
 		return nil, nil
 	}

--- a/provider.go
+++ b/provider.go
@@ -2,6 +2,7 @@ package oauth
 
 import (
 	"bytes"
+	"fmt"
 	"math"
 	"net/http"
 	"net/url"
@@ -63,7 +64,7 @@ func (provider *Provider) IsAuthorized(request *http.Request) (*string, error) {
 	// but my regex foo is low today.
 	authHeader := request.Header.Get(HTTP_AUTH_HEADER)
 	if strings.EqualFold(OAUTH_HEADER, authHeader[0:5]) {
-		return nil, nil
+		return nil, fmt.Errorf("no OAuth Authorization header")
 	}
 
 	authHeader = authHeader[5:]
@@ -89,12 +90,12 @@ func (provider *Provider) IsAuthorized(request *http.Request) (*string, error) {
 		return nil, err
 	}
 	if math.Abs(float64(int64(oauthTimeNumber)-provider.clock.Seconds())) > 5*60 {
-		return nil, nil
+		return nil, fmt.Errorf("too much clock skew")
 	}
 
 	consumerKey, ok := pars[CONSUMER_KEY_PARAM]
 	if !ok {
-		return nil, nil
+		return nil, fmt.Errorf("no consumer key")
 	}
 
 	consumer, err := provider.ConsumerGetter(consumerKey, pars)

--- a/provider.go
+++ b/provider.go
@@ -108,6 +108,21 @@ func (provider *Provider) IsAuthorized(request *http.Request) (*string, error) {
 		return nil, err
 	}
 
+	if consumer.serviceProvider.BodyHash {
+		bodyHash, err := calculateBodyHash(request, consumer.signer)
+		if err != nil {
+			return nil, err
+		}
+
+		sentHash, ok := pars[BODY_HASH_PARAM]
+
+		if bodyHash == "" && ok {
+			return nil, fmt.Errorf("body_hash must not be set")
+		} else if sentHash != bodyHash {
+			return nil, fmt.Errorf("body_hash mismatch")
+		}
+	}
+
 	userParams, err := parseBody(request)
 	if err != nil {
 		return nil, err

--- a/provider_test.go
+++ b/provider_test.go
@@ -27,6 +27,28 @@ func TestProviderIsAuthorizedGood(t *testing.T) {
 	assertEq(t, "consumerkey", *authorized)
 }
 
+func TestProviderIsAuthorizedWithBodyHash(t *testing.T) {
+	p := NewProvider(func(s string, h map[string]string) (*Consumer, error) {
+		c := NewConsumer(s, "consumersecret", ServiceProvider{BodyHash: true})
+		c.Debug(true)
+		return c, nil
+	})
+	p.clock = &MockClock{Time: 1446226936}
+
+	fakeRequest, err := http.NewRequest("GET", "https://example.com/some/path?q=query&q1=another_query", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Set header to good oauth1 header
+	fakeRequest.Header.Set(HTTP_AUTH_HEADER, "OAuth oauth_nonce=\"799507437267152061446226936\", oauth_timestamp=\"1446226936\", oauth_version=\"1.0\", oauth_signature_method=\"HMAC-SHA1\", oauth_consumer_key=\"consumerkey\", oauth_signature=\"RYUiwiUc5LHoipANhDxPbdFHgKc%3D\", oauth_body_hash=\"2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D\"")
+
+	authorized, err := p.IsAuthorized(fakeRequest)
+
+	assertEq(t, nil, err)
+	assertEq(t, "consumerkey", *authorized)
+}
+
 func TestConsumerKeyWithEqualsInIt(t *testing.T) {
 	p := NewProvider(func(s string, h map[string]string) (*Consumer, error) {
 		c := NewConsumer(s, "consumersecret", ServiceProvider{})

--- a/provider_test.go
+++ b/provider_test.go
@@ -23,8 +23,8 @@ func TestProviderIsAuthorizedGood(t *testing.T) {
 
 	authorized, err := p.IsAuthorized(fakeRequest)
 
-	assertEq(t, err, nil)
-	assertEq(t, *authorized, "consumerkey")
+	assertEq(t, nil, err)
+	assertEq(t, "consumerkey", *authorized)
 }
 
 func TestConsumerKeyWithEqualsInIt(t *testing.T) {
@@ -45,6 +45,6 @@ func TestConsumerKeyWithEqualsInIt(t *testing.T) {
 
 	authorized, err := p.IsAuthorized(fakeRequest)
 
-	assertEq(t, err, nil)
-	assertEq(t, *authorized, "consumerkeywithequals=")
+	assertEq(t, nil, err)
+	assertEq(t, "consumerkeywithequals=", *authorized)
 }

--- a/provider_test.go
+++ b/provider_test.go
@@ -19,7 +19,7 @@ func TestProviderIsAuthorizedGood(t *testing.T) {
 	}
 
 	// Set header to good oauth1 header
-	fakeRequest.Header.Set("Authorization", "OAuth oauth_nonce=\"799507437267152061446226936\", oauth_timestamp=\"1446226936\", oauth_version=\"1.0\", oauth_signature_method=\"HMAC-SHA1\", oauth_consumer_key=\"consumerkey\", oauth_signature=\"MOCK_SIGNATURE\"")
+	fakeRequest.Header.Set(HTTP_AUTH_HEADER, "OAuth oauth_nonce=\"799507437267152061446226936\", oauth_timestamp=\"1446226936\", oauth_version=\"1.0\", oauth_signature_method=\"HMAC-SHA1\", oauth_consumer_key=\"consumerkey\", oauth_signature=\"MOCK_SIGNATURE\"")
 
 	authorized, err := p.IsAuthorized(fakeRequest)
 
@@ -41,7 +41,7 @@ func TestConsumerKeyWithEqualsInIt(t *testing.T) {
 	}
 
 	// Set header to good oauth1 header
-	fakeRequest.Header.Set("Authorization", "OAuth oauth_nonce=\"799507437267152061446226936\", oauth_timestamp=\"1446226936\", oauth_version=\"1.0\", oauth_signature_method=\"HMAC-SHA1\", oauth_consumer_key=\"consumerkeywithequals=\", oauth_signature=\"MOCK_SIGNATURE\"")
+	fakeRequest.Header.Set(HTTP_AUTH_HEADER, "OAuth oauth_nonce=\"799507437267152061446226936\", oauth_timestamp=\"1446226936\", oauth_version=\"1.0\", oauth_signature_method=\"HMAC-SHA1\", oauth_consumer_key=\"consumerkeywithequals=\", oauth_signature=\"MOCK_SIGNATURE\"")
 
 	authorized, err := p.IsAuthorized(fakeRequest)
 

--- a/provider_test.go
+++ b/provider_test.go
@@ -13,7 +13,7 @@ func TestProviderIsAuthorizedGood(t *testing.T) {
 	})
 	p.clock = &MockClock{Time: 1446226936}
 
-	fakeRequest, err := http.NewRequest("GET", "https://example.com/some/path?q=query&q=another_query", nil)
+	fakeRequest, err := http.NewRequest("GET", "https://example.com/some/path?q=query&q1=another_query", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -35,7 +35,7 @@ func TestConsumerKeyWithEqualsInIt(t *testing.T) {
 	})
 	p.clock = &MockClock{Time: 1446226936}
 
-	fakeRequest, err := http.NewRequest("GET", "https://example.com/some/path?q=query&q=another_query", nil)
+	fakeRequest, err := http.NewRequest("GET", "https://example.com/some/path?q=query&q1=another_query", nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This patch fixes some bugs and adds some optional oauth features. I can break it up into multiple PRs if you wish. The following changes are included:

1. Normalize around using crypto.Hash constants
2. Rename SHA1 Signer to HMAC Signer
3. Add support for the SHA256 hash
4. Move "Authorization" token into a constant
5. Fix assert ordering in provider test
6. Factor parseBody out of RoundTrip, update provider.IsAuthorized to use helper functions
7. Add error messages to provider.
8. Fix missing unescape in provider, this causes signature mismatches if any of the oauth_ params have encoded elements. (Test in following commit.)
9. Add support for oauth_body_hash extension: https://oauth.googlecode.com/svn/spec/ext/body_hash/1.0/oauth-bodyhash.html