### PR TITLE
Look for Oauth params in form body or query string

### DIFF
--- a/oauth.go
+++ b/oauth.go
@@ -724,7 +724,7 @@ func canonicalizeUrl(u *url.URL) string {
 	return buf.String()
 }
 
-func parseBody(request *http.Request) (pairs, error) {
+func parseBody(request *http.Request) (map[string]string, error) {
 	userParams := map[string]string{}
 
 	// TODO(mrjones): factor parameter extraction into a separate method
@@ -764,16 +764,20 @@ func parseBody(request *http.Request) (pairs, error) {
 		}
 	}
 
+	return userParams, nil
+}
+
+func paramsToSortedPairs(params map[string]string) pairs {
 	// Sort parameters alphabetically
-	paramPairs := make(pairs, len(userParams))
+	paramPairs := make(pairs, len(params))
 	i := 0
-	for key, value := range userParams {
+	for key, value := range params {
 		paramPairs[i] = pair{key: key, value: value}
 		i++
 	}
 	sort.Sort(paramPairs)
 
-	return paramPairs, nil
+	return paramPairs
 }
 
 func calculateBodyHash(request *http.Request, s signer) (string, error) {
@@ -836,9 +840,10 @@ func (rt *RoundTripper) RoundTrip(userRequest *http.Request) (*http.Response, er
 	if err != nil {
 		return nil, err
 	}
+	paramPairs := paramsToSortedPairs(userParams)
 
-	for i := range userParams {
-		allParams.Add(userParams[i].key, userParams[i].value)
+	for i := range paramPairs {
+		allParams.Add(paramPairs[i].key, paramPairs[i].value)
 	}
 
 	baseString := rt.consumer.requestString(userRequest.Method, canonicalizeUrl(userRequest.URL), allParams)

--- a/provider.go
+++ b/provider.go
@@ -60,37 +60,41 @@ func makeURLAbs(url *url.URL, request *http.Request) {
 func (provider *Provider) IsAuthorized(request *http.Request) (*string, error) {
 	var err error
 
-	makeURLAbs(request.URL, request)
-
-	// Get the OAuth header vals. Probably would be better with regexp,
-	// but my regex foo is low today.
-	authHeader := request.Header.Get(HTTP_AUTH_HEADER)
-	if strings.EqualFold(OAUTH_HEADER, authHeader[0:5]) {
-		return nil, fmt.Errorf("no OAuth Authorization header")
+	// start with the body/query params
+	userParams, err := parseBody(request)
+	if err != nil {
+		return nil, err
 	}
 
-	authHeader = authHeader[5:]
-	params := strings.Split(authHeader, ",")
-	pars := make(map[string]string)
-	for _, param := range params {
-		vals := strings.SplitN(param, "=", 2)
-		k := strings.Trim(vals[0], " ")
-		v := strings.Trim(strings.Trim(vals[1], "\""), " ")
-		if strings.HasPrefix(k, "oauth") {
-			pars[k], err = url.QueryUnescape(v)
-			if err != nil {
-				return nil, err
+	// if the oauth params are in the Authorization header, grab them, and
+	// let them override what's in userParams
+	authHeader := request.Header.Get(HTTP_AUTH_HEADER)
+	if len(authHeader) > 5 && strings.EqualFold(OAUTH_HEADER, authHeader[0:5]) {
+		authHeader = authHeader[5:]
+		params := strings.Split(authHeader, ",")
+		for _, param := range params {
+			vals := strings.SplitN(param, "=", 2)
+			k := strings.Trim(vals[0], " ")
+			v := strings.Trim(strings.Trim(vals[1], "\""), " ")
+			if strings.HasPrefix(k, "oauth") {
+				userParams[k], err = url.QueryUnescape(v)
+				if err != nil {
+					return nil, err
+				}
 			}
 		}
 	}
-	oauthSignature, ok := pars[SIGNATURE_PARAM]
+
+	// pop the request's signature, it's not included in our signature
+	// calculation
+	oauthSignature, ok := userParams[SIGNATURE_PARAM]
 	if !ok {
 		return nil, fmt.Errorf("no oauth signature")
 	}
-	delete(pars, SIGNATURE_PARAM)
+	delete(userParams, SIGNATURE_PARAM)
 
 	// Check the timestamp
-	oauthTimeNumber, err := strconv.Atoi(pars[TIMESTAMP_PARAM])
+	oauthTimeNumber, err := strconv.Atoi(userParams[TIMESTAMP_PARAM])
 	if err != nil {
 		return nil, err
 	}
@@ -98,23 +102,28 @@ func (provider *Provider) IsAuthorized(request *http.Request) (*string, error) {
 		return nil, fmt.Errorf("too much clock skew")
 	}
 
-	consumerKey, ok := pars[CONSUMER_KEY_PARAM]
+	// get the oauth consumer key
+	consumerKey, ok := userParams[CONSUMER_KEY_PARAM]
 	if !ok {
 		return nil, fmt.Errorf("no consumer key")
 	}
 
-	consumer, err := provider.ConsumerGetter(consumerKey, pars)
+	// use it to create a consumer object
+	consumer, err := provider.ConsumerGetter(consumerKey, userParams)
 	if err != nil {
 		return nil, err
 	}
+	// TODO: dev testing.  remove me
+	consumer.Debug(true)
 
+	// if our consumer supports bodyhash, check it
 	if consumer.serviceProvider.BodyHash {
 		bodyHash, err := calculateBodyHash(request, consumer.signer)
 		if err != nil {
 			return nil, err
 		}
 
-		sentHash, ok := pars[BODY_HASH_PARAM]
+		sentHash, ok := userParams[BODY_HASH_PARAM]
 
 		if bodyHash == "" && ok {
 			return nil, fmt.Errorf("body_hash must not be set")
@@ -123,20 +132,12 @@ func (provider *Provider) IsAuthorized(request *http.Request) (*string, error) {
 		}
 	}
 
-	userParams, err := parseBody(request)
-	if err != nil {
-		return nil, err
-	}
-
 	allParams := NewOrderedParams()
-	for key, value := range pars {
+	for key, value := range userParams {
 		allParams.Add(key, value)
 	}
 
-	for i := range userParams {
-		allParams.Add(userParams[i].key, userParams[i].value)
-	}
-
+	makeURLAbs(request.URL, request)
 	baseString := consumer.requestString(request.Method, canonicalizeUrl(request.URL), allParams)
 	err = consumer.signer.Verify(baseString, oauthSignature)
 	if err != nil {

--- a/provider.go
+++ b/provider.go
@@ -59,9 +59,10 @@ func makeURLAbs(url *url.URL, request *http.Request) {
 // or nil if not authorized
 func (provider *Provider) IsAuthorized(request *http.Request) (*string, error) {
 	var err error
+	var userParams map[string]string
 
 	// start with the body/query params
-	userParams, err := parseBody(request)
+	userParams, err = parseBody(request)
 	if err != nil {
 		return nil, err
 	}
@@ -69,8 +70,8 @@ func (provider *Provider) IsAuthorized(request *http.Request) (*string, error) {
 	// if the oauth params are in the Authorization header, grab them, and
 	// let them override what's in userParams
 	authHeader := request.Header.Get(HTTP_AUTH_HEADER)
-	if len(authHeader) > 5 && strings.EqualFold(OAUTH_HEADER, authHeader[0:5]) {
-		authHeader = authHeader[5:]
+	if len(authHeader) > 6 && strings.EqualFold(OAUTH_HEADER, authHeader[0:6]) {
+		authHeader = authHeader[6:]
 		params := strings.Split(authHeader, ",")
 		for _, param := range params {
 			vals := strings.SplitN(param, "=", 2)
@@ -113,8 +114,6 @@ func (provider *Provider) IsAuthorized(request *http.Request) (*string, error) {
 	if err != nil {
 		return nil, err
 	}
-	// TODO: dev testing.  remove me
-	consumer.Debug(true)
 
 	// if our consumer supports bodyhash, check it
 	if consumer.serviceProvider.BodyHash {

--- a/provider_test.go
+++ b/provider_test.go
@@ -79,7 +79,7 @@ func TestProviderIsAuthorizedOauthParamsInQuery(t *testing.T) {
 	oauthParams.Set("oauth_timestamp", "1446226936")
 	oauthParams.Set("oauth_version", "1.0")
 	encodedOauthParams := oauthParams.Encode()
-	url :=  "https://example.com/some/path?q=query&q1=another_query&" + encodedOauthParams
+	url := "https://example.com/some/path?q=query&q1=another_query&" + encodedOauthParams
 
 	fakeRequest, err := http.NewRequest("GET", url, nil)
 	if err != nil {


### PR DESCRIPTION
Per [the spec](https://tools.ietf.org/html/rfc5849#section-3.5), those are also valid ways to send oauth parameters in a request.  And [LTI](http://www.edu-apps.org/code.html) launches (as shown by [this test launcher](http://lti.tools/test/tc.php)) use the form-encoded body method.