### PR TITLE
Consumer holds a nonceGenerator interface instance

### DIFF
--- a/oauth.go
+++ b/oauth.go
@@ -203,7 +203,7 @@ type Consumer struct {
 	// Private seams for mocking dependencies when testing
 	clock clock
 	// Seeded generators are not reentrant
-	nonceGenerator *lockedNonceGenerator
+	nonceGenerator nonceGenerator
 	signer         signer
 }
 


### PR DESCRIPTION
Due to a line changed in PR #48 the tests no longer compiled

The issue is that `Consumer` should be holding an instance of the `nonceGenerator` interface so that the tests can mock that dependency. PR #48 had switched this dependency to explicitly be a `*lockedNonceGenerator`

Tagging @dsajanice to make sure this is reasonable since she authored #48

