### PR TITLE
Allows consumers to configure whether or not to check for the timestamp

### DIFF
--- a/oauth.go
+++ b/oauth.go
@@ -136,6 +136,7 @@ type ServiceProvider struct {
 	AccessTokenUrl    string
 	HttpMethod        string
 	BodyHash          bool
+	IgnoreTimestamp   bool
 }
 
 func (sp *ServiceProvider) httpMethod() string {


### PR DESCRIPTION
Some providers allow a loose implementation of oauth1. The use-case we are experiencing is that our mobile team sends oauth requests with a 13-digit timestamp.