### PR TITLE
Return err if no consumer key is present during validation

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -96,7 +96,7 @@ func (provider *Provider) IsAuthorized(request *http.Request) (*string, error) {
 
 	// get the oauth consumer key
 	consumerKey, ok := userParams[CONSUMER_KEY_PARAM]
-	if !ok {
+	if !ok || consumerKey == "" {
 		return nil, fmt.Errorf("no consumer key")
 	}
 


### PR DESCRIPTION
Fixes the fact the case when you create a consumer with a blank consumerKey. Currently, validation will pass a.k.a won't return an error. This will return an error.