### PR TITLE
Handles url escaped signatures

### DIFF
--- a/oauth.go
+++ b/oauth.go
@@ -1107,7 +1107,10 @@ func (s *HMACSigner) Verify(message string, signature string) error {
 	}
 
 	if validSignature != signature {
-		return fmt.Errorf("signature did not match")
+		decodedSigniture, _ := url.QueryUnescape(signature)
+		if validSignature != decodedSigniture {
+			return fmt.Errorf("signature did not match")
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Clients may send the oauth header with the signature encoded. for example:
**encoded signature**: ktNiKPi15g3JFnSxn8X%2FxjUQH5E%3D

When the library signs the request for comparison it will not encoded it. for example:
**validSignature**: ktNiKPi15g3JFnSxn8X/xjUQH5E=
_error! signature does not match_

This patch will encode the signature and try again before returning an error