### PR TITLE
Allows providers to include query string params in the base string for signing

### DIFF
--- a/oauth.go
+++ b/oauth.go
@@ -137,6 +137,7 @@ type ServiceProvider struct {
 	HttpMethod        string
 	BodyHash          bool
 	IgnoreTimestamp   bool
+	SignQueryParams   bool
 }
 
 func (sp *ServiceProvider) httpMethod() string {

--- a/provider.go
+++ b/provider.go
@@ -124,6 +124,13 @@ func (provider *Provider) IsAuthorized(request *http.Request) (*string, error) {
 		}
 	}
 
+	// Include the query string params in the base string
+	if consumer.serviceProvider.SignQueryParams {
+		for k, v := range request.URL.Query() {
+			userParams[k] = strings.Join(v, "")
+		}
+	}
+
 	// if our consumer supports bodyhash, check it
 	if consumer.serviceProvider.BodyHash {
 		bodyHash, err := calculateBodyHash(request, consumer.signer)


### PR DESCRIPTION
Hey MrJones!

So this PR is a little different. The issue we were having is that one of our devices (Roku) does not follow the oAuth specification as strictly as it should. The device is sending a POST request with query-string-parameters in the URL. Normally these values should not be included in the base string that get signed, however our company decided to tolerate this as this situation may exist in other devices.

I would like to continue to use your library instead of forking and adding our own logic so I submit this PR in case you find that it would be useful in your library as an option that is off by default.