### PR TITLE
Read http Request bodies in a go1.8+ compliant manner

### DIFF
--- a/oauth.go
+++ b/oauth.go
@@ -674,8 +674,12 @@ func (c *Consumer) makeAuthorizedRequestReader(method string, urlString string, 
 
 	} else {
 		// TODO(mrjones): validate that we're not overrideing an exising body?
-		request.Body = ioutil.NopCloser(strings.NewReader(vals.Encode()))
 		request.ContentLength = int64(len(vals.Encode()))
+		if request.ContentLength == 0 {
+			request.Body = http.NoBody
+		} else {
+			request.Body = ioutil.NopCloser(strings.NewReader(vals.Encode()))
+		}
 	}
 
 	for k, vs := range c.AdditionalHeaders {

--- a/oauth_test.go
+++ b/oauth_test.go
@@ -1040,6 +1040,52 @@ func TestBodyHashStandard(t *testing.T) {
 
 }
 
+func TestParseBodyNonDestructive(t *testing.T) {
+	// copied from unexported http.Request.outgoingLength()
+	// https://github.com/golang/go/blob/release-branch.go1.8/src/net/http/request.go#L1311
+	outgoingLength := func(r *http.Request) int64 {
+		if r.Body == nil || r.Body == http.NoBody {
+			return 0
+		}
+		if r.ContentLength != 0 {
+			return r.ContentLength
+		}
+		return -1
+	}
+	const assertMsg = "Unexpected change in http.Request Body"
+
+	req, err := http.NewRequest("POST", "http://www.mrjon.es/someurl", strings.NewReader(`foo=123`))
+	assertEq(t, nil, err)
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	len := outgoingLength(req)
+	_, err = parseBody(req)
+	assertEq(t, nil, err)
+	assertEqM(t, len, outgoingLength(req), assertMsg)
+
+	req, err = http.NewRequest("POST", "http://www.mrjon.es/someurl", strings.NewReader(""))
+	assertEq(t, nil, err)
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	len = outgoingLength(req)
+	_, err = parseBody(req)
+	assertEq(t, nil, err)
+	assertEqM(t, len, outgoingLength(req), assertMsg)
+
+	req, err = http.NewRequest("GET", "http://www.mrjon.es/someurl?foo=123", nil)
+	assertEq(t, nil, err)
+	len = outgoingLength(req)
+	_, err = parseBody(req)
+	assertEq(t, nil, err)
+	assertEqM(t, len, outgoingLength(req), assertMsg)
+
+	req, err = http.NewRequest("GET", "http://www.mrjon.es/someurl", nil)
+	assertEq(t, nil, err)
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	len = outgoingLength(req)
+	_, err = parseBody(req)
+	assertEq(t, nil, err)
+	assertEqM(t, len, outgoingLength(req), assertMsg)
+}
+
 func basicConsumer() *Consumer {
 	return NewConsumer(
 		"consumerkey",


### PR DESCRIPTION
This updates the way that http.Request Bodies are read in oauth.go to comply with Client & Transport changes to the net/http library in Go 1.8+.

https://golang.org/doc/go1.8#net_http

Specifically of interest here is the statement:
> The Transport no longer reads a byte of a non-nil Request.Body when the Request.ContentLength is zero to determine whether the ContentLength is actually zero or just undefined. To explicitly signal that a body has zero length, either set it to nil, or set it to the new value NoBody. The new NoBody value is intended for use by Request constructor functions; it is used by NewRequest.

When reading the request body to calculate the content hash or to parse form-encoded query args, the NoBody value is being overwritten with an empty ReadCloser, even though the Content Length is 0.  The impact of this is that as far as the net/http library is concerned, a Request which is passed to provider.IsAuthorized with a Content Length of 0 (Request.ContentLength ==0 && Request.Body == NoBody) is modified during the parsing/hash calc process such that it's effective Content Length is now undefined  (Request.ContentLength ==0 && Request.Body != NoBody).  

As a result, passing a Reqeust to IsAuthorized unexpected changes the behavior of that request. e.g. the http Client will happily handle redirects with a 307 or 308 Status for requests with a body length of 0, but but it will not handle redirects with an undefined body length. 

**Version Compatibility Issues**
These changes will only compile with go 1.8+. Let me know if you'd prefer I reopen this PR against a different upstream branch to maintain some minimum-go-version compatibility on master.