### PR TITLE
Ignore missing verification code when authorizing token

### DIFF
--- a/oauth.go
+++ b/oauth.go
@@ -451,8 +451,10 @@ func (c *Consumer) AuthorizeToken(rtoken *RequestToken, verificationCode string)
 
 func (c *Consumer) AuthorizeTokenWithParams(rtoken *RequestToken, verificationCode string, additionalParams map[string]string) (atoken *AccessToken, err error) {
 	params := map[string]string{
-		VERIFIER_PARAM: verificationCode,
-		TOKEN_PARAM:    rtoken.Token,
+		TOKEN_PARAM: rtoken.Token,
+	}
+	if verificationCode != "" {
+		params[VERIFIER_PARAM] = verificationCode
 	}
 	return c.makeAccessTokenRequestWithParams(params, rtoken.Secret, additionalParams)
 }

--- a/oauth_test.go
+++ b/oauth_test.go
@@ -192,6 +192,36 @@ func TestSuccessfulTokenAuthorization(t *testing.T) {
 	assertEq(t, "consumersecret&RSECRET", m.signer.UsedKey)
 }
 
+func TestSuccessfulTokenAuthorizationWithoutVerifier(t *testing.T) {
+	c := basicConsumer()
+	m := newMocks(t)
+	m.install(c)
+
+	m.httpClient.ExpectGet(
+		"http://www.mrjon.es/accesstoken",
+		map[string]string{
+			"oauth_consumer_key":     "consumerkey",
+			"oauth_nonce":            "2",
+			"oauth_signature":        "MOCK_SIGNATURE",
+			"oauth_signature_method": "HMAC-SHA1",
+			"oauth_timestamp":        "1",
+			"oauth_token":            "RTOKEN",
+			"oauth_version":          "1.0",
+		},
+		"oauth_token=ATOKEN&oauth_token_secret=ATOKEN_SECRET&oauth_session_handle=SESSION_HANDLE")
+
+	rtoken := &RequestToken{Token: "RTOKEN", Secret: "RSECRET"}
+	atoken, err := c.AuthorizeToken(rtoken, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assertEq(t, "ATOKEN", atoken.Token)
+	assertEq(t, "ATOKEN_SECRET", atoken.Secret)
+	assertEq(t, "SESSION_HANDLE", atoken.AdditionalData["oauth_session_handle"])
+	assertEq(t, "consumersecret&RSECRET", m.signer.UsedKey)
+}
+
 func TestSuccessfulTokenRefresh(t *testing.T) {
 	c := basicConsumer()
 	m := newMocks(t)


### PR DESCRIPTION
Some OAuth1 implementations do not use the `oauth_verifier` even though they should. In such cases, the token authorization step ignores the `oauth_verifier` field when building the `oauth_signature`. For such implementations, this library will build a signature which will be rejected by the server.

This patch ensures that the verification code is only added as a param if provided or not empty.