### PR TITLE
Return http execute error for authentication

### DIFF
--- a/oauth.go
+++ b/oauth.go
@@ -1241,7 +1241,7 @@ func (c *Consumer) requestString(method string, url string, params *OrderedParam
 func (c *Consumer) getBody(method, url string, oauthParams *OrderedParams) (*string, error) {
 	resp, err := c.httpExecute(method, url, "", 0, nil, oauthParams)
 	if err != nil {
-		return nil, errors.New("httpExecute: " + err.Error())
+		return nil, err
 	}
 	bodyBytes, err := ioutil.ReadAll(resp.Body)
 	resp.Body.Close()


### PR DESCRIPTION
I'm using `oauth` on a legacy server, which returns XML body in cases like consumer key invalid and a few other endpoints.

I want to extract the body and parse the message, so I changed the `getBody` method from returning an `errorString` to simply the `HTTPExecuteError` so I can access every detail of the error.